### PR TITLE
SongItem onContextMenu prevent browser event

### DIFF
--- a/app/components/item/SongItem.js
+++ b/app/components/item/SongItem.js
@@ -55,7 +55,10 @@ const SongItem = ({ song, queue, index, isIndex = false, isPlaying = false, setI
 			style={({ pressed }) => ([mainStyles.opacity({ pressed }), styles.song, style])}
 			key={song.id}
 			onLongPress={() => setIndexOptions(index)}
-			onContextMenu={() => setIndexOptions(index)}
+			onContextMenu={(ev) => {
+				ev.preventDefault()
+				return setIndexOptions(index)
+			}}
 			delayLongPress={200}
 			onPress={() => {
 				onPress(song)


### PR DESCRIPTION
RMB event in web over `SongItem` causes to appear browser's context menu.

This patch disables that behavior.