### PR TITLE
feat: add support for explicit and clean status badges (OpenSubsonic)

### DIFF
--- a/app/components/ExplicitBadge.js
+++ b/app/components/ExplicitBadge.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { View, Text } from 'react-native'
+
+const ExplicitBadge = ({ status, color, style }) => {
+	if (status !== 'explicit' && status !== 'clean') {
+		return null
+	}
+
+	return (
+		<View style={[{borderWidth: 1, borderColor: color, borderRadius: 2, width: 13, height: 13, justifyContent: 'center', alignItems: 'center', marginRight: 5}]}>
+			<Text style={{color: color, fontSize: 9, fontWeight: 'bold', includeFontPadding: false}}>
+				{status === 'explicit' ? 'E' : 'C'}
+			</Text>
+		</View>
+	)
+}
+
+export default ExplicitBadge

--- a/app/components/item/SongItem.js
+++ b/app/components/item/SongItem.js
@@ -10,6 +10,7 @@ import { useSongDispatch } from '~/contexts/song'
 import { useTheme } from '~/contexts/theme'
 import { urlCover } from '~/utils/url'
 import FavoritedButton from '~/components/button/FavoritedButton'
+import ExplicitBadge from '~/components/ExplicitBadge'
 import ImageError from '~/components/ImageError'
 import mainStyles from '~/styles/main'
 import size from '~/styles/size'
@@ -51,6 +52,7 @@ const SongItem = ({ song, queue, index, isIndex = false, isPlaying = false, setI
 	const config = useConfig()
 	const settings = useSettings()
 	const [isHover, setIsHover] = React.useState(false)
+	const titleColor = isPlaying ? theme.primaryTouch : theme.primaryText;
 
 	return (
 		<Pressable
@@ -84,9 +86,12 @@ const SongItem = ({ song, queue, index, isIndex = false, isPlaying = false, setI
 				/>
 			</View>
 			<View style={{ flex: 1, flexDirection: 'column' }}>
-				<Text numberOfLines={1} style={[mainStyles.mediumText(isPlaying ? theme.primaryTouch : theme.primaryText), { marginBottom: 2 }]}>
-					{(isIndex && song.track !== undefined) ? `${song.track}. ` : null}{song.title}
-				</Text>
+        <		View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 2 }}>
+					<ExplicitBadge status={song.explicitStatus} color={titleColor} />
+					<Text numberOfLines={1} style={[mainStyles.mediumText(titleColor), { flexShrink: 1 }]}>
+						{(isIndex && song.track !== undefined) ? `${song.track}. ` : null}{song.title}
+					</Text>
+				</View>
 				<Text numberOfLines={1} style={mainStyles.smallText(theme.secondaryText)}>
 					{song.artist}
 				</Text>

--- a/app/components/player/BoxDesktopPlayer.js
+++ b/app/components/player/BoxDesktopPlayer.js
@@ -12,6 +12,7 @@ import IconButton from '~/components/button/IconButton'
 import ImageError from '~/components/ImageError'
 import SlideBar from '~/components/button/SlideBar'
 import FavoritedButton from '~/components/button/FavoritedButton'
+import ExplicitBadge from '~/components/ExplicitBadge'
 import size from '~/styles/size'
 import PlayButton from '~/components/button/PlayButton'
 
@@ -44,7 +45,12 @@ const BoxDesktopPlayer = ({ setFullScreen }) => {
 					</View>
 				</ImageError>
 				<View style={{ justifyContent: 'center', gap: 2, flex: Platform.select({ web: 1, default: 0 }), maxWidth: 'min-content' }}>
-					<Text numberOfLines={1} style={{ color: theme.primaryText, textAlign: 'left', fontWeight: 'bold', maxWidth: 400 }}>{song?.songInfo?.track ? `${song?.songInfo?.track}. ` : null}{song?.songInfo?.title ? song.songInfo.title : 'Song title'}</Text>
+					<View style={{ flexDirection: 'row', alignItems: 'center', maxWidth: 400 }}>
+						<ExplicitBadge status={song?.songInfo?.explicitStatus} color={theme.primaryText} />
+						<Text numberOfLines={1} style={{ color: theme.primaryText, textAlign: 'left', fontWeight: 'bold', flexShrink: 1 }}>
+							{song?.songInfo?.track ? `${song?.songInfo?.track}. ` : null}{song?.songInfo?.title ? song.songInfo.title : 'Song title'}
+						</Text>
+					</View>
 					<Text numberOfLines={1} style={{ color: theme.secondaryText, textAlign: 'left', maxWidth: 400 }}>{song?.songInfo?.artist ? song.songInfo.artist : 'Artist'}</Text>
 				</View>
 				<FavoritedButton

--- a/app/components/player/BoxPlayer.js
+++ b/app/components/player/BoxPlayer.js
@@ -11,6 +11,7 @@ import PlayButton from '~/components/button/PlayButton'
 import Player from '~/utils/player'
 import IconButton from '~/components/button/IconButton'
 import ImageError from '~/components/ImageError'
+import ExplicitBadge from '~/components/ExplicitBadge'
 import size from '~/styles/size'
 import useKeyboardIsOpen from '~/utils/useKeyboardIsOpen'
 
@@ -48,8 +49,15 @@ const BoxPlayer = ({ setFullScreen }) => {
 				</View>
 			</ImageError>
 			<View style={{ flex: 1 }}>
-				<Text style={{ color: theme.playerPrimaryText, textAlign: 'left', flex: 1, fontWeight: 'bold' }} numberOfLines={1}>{song?.songInfo?.track ? `${song?.songInfo?.track}. ` : null}{song?.songInfo?.title ? song.songInfo.title : 'Song title'}</Text>
-				<Text style={{ color: theme.playerSecondaryText, textAlign: 'left', flex: 1 }} numberOfLines={1}>{song?.songInfo?.artist ? song.songInfo.artist : 'Artist'}</Text>
+				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
+					<ExplicitBadge status={song?.songInfo?.explicitStatus} color={theme.playerPrimaryText} />
+					<Text style={{ color: theme.playerPrimaryText, textAlign: 'left', flexShrink: 1, fontWeight: 'bold' }} numberOfLines={1}>
+						{song?.songInfo?.track ? `${song?.songInfo?.track}. ` : null}{song?.songInfo?.title ? song.songInfo.title : 'Song title'}
+					</Text>
+				</View>
+				<Text style={{ color: theme.playerSecondaryText, textAlign: 'left' }} numberOfLines={1}>
+					{song?.songInfo?.artist ? song.songInfo.artist : 'Artist'}
+				</Text>
 			</View>
 			<IconButton
 				icon="step-forward"

--- a/app/components/player/FullScreenHorizontalPlayer.js
+++ b/app/components/player/FullScreenHorizontalPlayer.js
@@ -20,6 +20,7 @@ import size from '~/styles/size'
 import SlideBar from '~/components/button/SlideBar'
 import SlideControl from '~/components/button/SlideControl'
 import ConnectButton from '~/components/button/ConnectButton'
+import ExplicitBadge from '~/components/ExplicitBadge'
 
 const preview = {
 	COVER: 0,
@@ -150,7 +151,12 @@ const FullScreenHorizontalPlayer = ({ setFullScreen }) => {
 								size={size.icon.medium}
 								style={{ padding: 0, paddingBottom: 10, marginStart: 20, width: 'min-content' }}
 							/>
-							<Text numberOfLines={1} style={styles.title}>{song?.songInfo?.title}</Text>
+							<View style={{ flexDirection: 'row', alignItems: 'center', marginHorizontal: 20 }}>
+								<ExplicitBadge status={song?.songInfo?.explicitStatus} color={color.primary} />
+								<Text numberOfLines={1} style={[styles.title, { marginHorizontal: 0, flexShrink: 1 }]}>
+									{song?.songInfo?.title}
+								</Text>
+							</View>
 							<Text numberOfLines={1} style={styles.artist}>{song?.songInfo?.artist}</Text>
 						</View>
 					</SlideControl>
@@ -189,9 +195,12 @@ const FullScreenHorizontalPlayer = ({ setFullScreen }) => {
 										}}
 									>
 										<View style={{ flex: 1, flexDirection: 'column' }}>
-											<Text numberOfLines={1} style={{ color: song.index === index ? theme.primaryTouch : color.primary, fontSize: size.text.medium, marginBottom: 2, textAlign: 'right' }}>
-												{item.title}
-											</Text>
+											<View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'flex-end', marginBottom: 2 }}>
+												<ExplicitBadge status={item.explicitStatus} color={song.index === index ? theme.primaryTouch : color.primary} />
+												<Text numberOfLines={1} style={{ color: song.index === index ? theme.primaryTouch : color.primary, fontSize: size.text.medium, textAlign: 'right', flexShrink: 1 }}>
+													{item.title}
+												</Text>
+											</View>
 											<Text numberOfLines={1} style={{ color: color.secondary, fontSize: size.text.small, textAlign: 'right' }}>
 												{item.artist}
 											</Text>

--- a/app/components/player/FullScreenPlayer.js
+++ b/app/components/player/FullScreenPlayer.js
@@ -23,6 +23,8 @@ import SlideBar from '~/components/button/SlideBar'
 import SlideControl from '~/components/button/SlideControl'
 import SongItem from '~/components/item/SongItem'
 import ConnectButton from '~/components/button/ConnectButton'
+import ExplicitBadge from '~/components/ExplicitBadge'
+
 
 const preview = {
 	COVER: 0,
@@ -198,7 +200,10 @@ const FullScreenPlayer = ({ setFullScreen }) => {
 									setFullScreen(false)
 								}}
 							>
-								<Text numberOfLines={1} style={{ color: theme.primaryText, fontSize: size.title.small, textAlign: 'left', fontWeight: 'bold' }}>{song.songInfo.title}</Text>
+								<ExplicitBadge status={song?.songInfo?.explicitStatus} color={theme.primaryText} />
+								<Text numberOfLines={1} style={{ color: theme.primaryText, fontSize: size.title.small, textAlign: 'left', fontWeight: 'bold', flexShrink: 1 }}>
+									{song.songInfo.title}
+								</Text>
 							</Pressable>
 							<Pressable
 								style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}

--- a/app/contexts/song/provider.js
+++ b/app/contexts/song/provider.js
@@ -55,6 +55,7 @@ const convertTrack = (track) => {
 		size: track.size,
 		index: track.index,
 		mediaType: track.mediaType,
+		explicitStatus: track.explicitStatus,
 		// radio
 		homePageUrl: track.homePageUrl,
 		name: track.name,


### PR DESCRIPTION
#### **Summary**
This PR implements visual indicators for tracks marked as `explicit` or `clean`. It leverages the `explicitStatus` field provided by Navidrome and other OpenSubsonic-compliant servers (derived from the `ITUNESADVISORY` tag).

#### **Key Changes**
- **Data Persistence**: Updated `convertTrack` in `SongProvider.js` to include the `explicitStatus` field. Previously, this metadata was stripped when tracks were added to the player queue to save space, preventing the badges from showing in the player views.
- **New Component**: Created `ExplicitBadge.js` — a reusable, lightweight component to display "E" (Explicit) and "C" (Clean) badges.
- **UI Integration**: Added the badge to all primary views for a consistent experience:
    - `SongItem`: Track lists and search results.
    - `BoxPlayer` & `BoxDesktopPlayer`: Mobile and desktop mini-players.
    - `FullScreenPlayer` & `FullScreenHorizontalPlayer`: Full-screen playback views.
- **Styling**: Badges automatically inherit the text color of the current theme (e.g., `primaryTouch` when playing) and use `flexShrink` to ensure proper layout truncation on smaller screens.

#### **Screenshots / UI Behavior**
- **Explicit**: Displays a boxed "E" next to the track title.
- **Clean**: Displays a boxed "C" next to the track title.
- **None**: No badge is displayed (default).

#### **Technical Note**
The implementation follows the **OpenSubsonic** specification where `explicitStatus` can be `explicit`, `clean`, or `none`.

<img width="668" height="916" alt="изображение" src="https://github.com/user-attachments/assets/8a045eb3-c8a2-4644-8371-fa9224a27dcb" />
<img width="1853" height="983" alt="изображение" src="https://github.com/user-attachments/assets/c6ea7379-e8fe-47a1-895a-774f5efda97b" />
<img width="1853" height="977" alt="изображение" src="https://github.com/user-attachments/assets/ac62c915-edef-4dde-94e3-e553076a319a" />
