### PR TITLE
Fix: visible ui icons for same colored background

### DIFF
--- a/app/components/PresHeader.js
+++ b/app/components/PresHeader.js
@@ -21,13 +21,19 @@ const PresHeader = ({ title, subTitle, imgSrc, onPressTitle = null, onPressOptio
 					<IconButton
 						icon="ellipsis-h"
 						onPress={onPressOption}
-						color={'white'}
+						color={theme.primaryTouch}
 						style={{
 							position: 'absolute',
-							padding: 20,
+							width: 50,
+							height: 50,
+							padding: 10,
+							margin: 10,
 							top: insets.top,
 							right: insets.left,
-							zIndex: 1
+							borderRadius: '50%',
+							zIndex: 1,
+							alignItems: 'center',
+							backgroundColor: `${theme.backgroundTouch}c0`, // add 75% opacity
 						}}
 					/> : null
 			}

--- a/app/components/button/BackButton.js
+++ b/app/components/button/BackButton.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useNavigation } from '@react-navigation/native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { useTheme } from '~/contexts/theme'
 
 import IconButton from '~/components/button/IconButton'
 import size from '~/styles/size'
@@ -8,19 +9,26 @@ import size from '~/styles/size'
 const BackButton = () => {
 	const navigation = useNavigation()
 	const insets = useSafeAreaInsets()
+	const theme = useTheme()
 
 	return (
 		<IconButton
 			style={{
 				position: 'absolute',
+				width: 50,
+				height: 50,
 				top: insets.top,
 				left: insets.left,
-				padding: 20,
+				borderRadius: '50%',
+				padding: 10,
+				margin: 10,
 				zIndex: 2,
+				alignItems: 'center',
+				backgroundColor: `${theme.backgroundTouch}c0`, // add 75% opacity
 			}} onPress={() => navigation.goBack()}
 			icon="chevron-left"
 			size={size.icon.small}
-			color="#fff"
+			color={theme.primaryTouch}
 		/>
 	)
 }


### PR DESCRIPTION
Closes #129 

<img width="1403" height="385" alt="image" src="https://github.com/user-attachments/assets/9c7fcf42-40e5-4dfa-8cd8-13251b02523d" />

Notes:
- Used `theme.primaryTouch` for the UI icon color.
- Used `theme.backgroundTouch` for the circular background color with a 75% opacity.