### PR TITLE
Fix: missing username parameter in getUser api call

### DIFF
--- a/app/screens/Settings/Informations.js
+++ b/app/screens/Settings/Informations.js
@@ -34,7 +34,7 @@ const InformationsSettings = () => {
 	const config = useConfig()
 	const [server, setServer] = React.useState({})
 
-	const [user] = useCachedAndApi([], 'getUser', {}, (json, setData) => {
+	const [user] = useCachedAndApi([], 'getUser', { username: config.username }, (json, setData) => {
 		setServer({
 			version: json.serverVersion,
 			name: json.type,


### PR DESCRIPTION
Missing required parameter `username` in `getUser` getting no information in the `Settings -> Information` page. Added it so that the Information page should display the correct details.

Subsonic API [getUser](https://subsonic.org/pages/api.jsp#getUser)